### PR TITLE
Don't allow stderr to screw up `output`

### DIFF
--- a/mounch.py
+++ b/mounch.py
@@ -111,7 +111,7 @@ def main():
     ],
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
-        stderr=subprocess.STDOUT)
+        stderr=subprocess.PIPE)
     stdout = popo.communicate(input=stringto)[0]
     output = stdout.decode().strip()
     if not output:


### PR DESCRIPTION
The standard error was redirected to the standard output and this can screw up `output`. A missing icon would provoke this for example.